### PR TITLE
Uppercase C causes an error on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This will print in your console something like:
 `haxelib install console.hx`
 
 And add
-`-lib Console.hx` when compiling your haxe code
+`-lib console.hx` when compiling your haxe code
 
 ### API
 


### PR DESCRIPTION
Minor change that avoids a compiling error in case an user copypastes this line to their .hxml file on Linux